### PR TITLE
Fix condensed SDRF parsing for unmelt script

### DIFF
--- a/unmelt_condensed.R
+++ b/unmelt_condensed.R
@@ -82,7 +82,7 @@ ucfirst <- function(string) {
 # Read condensed SDRF
 
 print(paste('Reading', opt[['input_file']], '...'))
-condensed <- fread(opt[['input_file']], header=F, stringsAsFactors = FALSE, fill = TRUE)
+condensed <- fread(opt[['input_file']], header=F, stringsAsFactors = FALSE, fill = TRUE, sep="\t")
 print('...done')
 
 # Apply logic to set which fields are which


### PR DESCRIPTION
Not sure why this hasn't been an issue previously- but it's cropped up for one dataset in particular. Need to explicitly set the tab delimiter for unmelt.

I don't believe this is used anywhere in production right now, so only has relevance for my new pipelines which inject the wide metadata table into tertiary analysis. 