### PR TITLE
GXA and SCXA privacy checks

### DIFF
--- a/public_private_ae2_to_atlas.sh
+++ b/public_private_ae2_to_atlas.sh
@@ -100,7 +100,7 @@ for l in $(cat "$all_atlas_experiments_file"); do
                   if [ $atlas_private_flag == "true" ]; then
                         # Experiment public in AE2 and private in Atlas - make it public in Atlas
                         echo -e "\n$exp_accession - AE2: public; Atlas: private - status change in Atlas: private->public"  >> $process_file.log
-                      curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public" >> $process_file.log
+                        curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public" >> $process_file.log
                         echo "$exp_accession" >> $exps_public_in_atlas
                       # At this point, the last line of $process_file.log should contain something like 'Experiment E-GEOD-10406 successfully updated.200'
                       # where 200 is the http response code - fail if the response code is not $SUCCESS_HTTP_RESPONSE
@@ -118,7 +118,7 @@ for l in $(cat "$all_atlas_experiments_file"); do
                    if [ $atlas_private_flag == "false" ]; then
                       # Experiment private in AE2 and public in Atlas - make it private in Atlas
                       echo -e "\n$exp_accession - AE2: private; Atlas: public - status change in Atlas: public->private" >> $process_file.log
-                    curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private" >> $process_file.log
+                      curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private" >> $process_file.log
                       echo "$exp_accession" >> $exps_private_in_atlas
                     httpCode=`tail -1 $process_file.log | awk -F"]" '{print $NF}'`
                     if [ "$httpCode" -ne "$SUCCESS_HTTP_RESPONSE" ]; then

--- a/public_private_ae2_to_atlas.sh
+++ b/public_private_ae2_to_atlas.sh
@@ -24,6 +24,7 @@ GXA_OR_SCXA=$1
 [ ! -z ${ATLAS_ADMIN_UID+x} ] || (echo "Env var ATLAS_ADMIN_UID not defined." && exit 1)
 [ ! -z ${ATLAS_ADMIN_PASS+x} ] || (echo "Env var ATLAS_ADMIN_PASS not defined." && exit 1)
 [ ! -z ${ERROR_NOTIFICATION_EMAILADDRESS+x} ] || (echo "Env var ERROR_NOTIFICATION_EMAILADDRESS not defined." && exit 1)
+[ ! -z ${expsDir+x} ] || (echo "Env var expsDir not defined." && exit 1)
 
 
 SUCCESS_HTTP_RESPONSE=200
@@ -42,10 +43,6 @@ touch $process_file.log
 
 
 if [ $GXA_OR_SCXA == 'gxa' ]; then
-  expsDir=$ATLAS_EXPS
-  if [ "$ATLAS_URL" == "ves-hx-77.ebi.ac.uk:8080/gxa" ]; then
-    expsDir=${expsDir}_test
-  fi
 
   # Fetch the list of experiment privacies in Atlas.
   # we will removing PanCancer experiments (E-MTAB-5200 and E-MTAB-5423) as they dont want to be checked, as we want to keep them public
@@ -60,10 +57,6 @@ if [ $GXA_OR_SCXA == 'gxa' ]; then
 fi
 
 if [ $GXA_OR_SCXA == 'scxa' ]; then
-  expsDir=$ATLAS_SC_EXPERIMENTS
-  if [ "$ATLAS_URL" == "ves-hx-77.ebi.ac.uk:8080/gxa/sc" ]; then
-    expsDir=$ATLAS_SC_EXPERIMENTS
-  fi
 
   ## Fetch the list of single cell studies accessions and associated privacy status from webAPI
   curl -s -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} "${ATLAS_URL}/admin/experiments/all/list" | jq -r '.[].result | [.accession, .isPrivate] | @tsv' > $all_atlas_experiments_file

--- a/public_private_ae2_to_atlas.sh
+++ b/public_private_ae2_to_atlas.sh
@@ -1,24 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @author: rpetry
 # @date:   7 Aug 2013§
 
-# This script serves to reflect in Atlas private/public experiment status switch on the AE2 side.
+shopt -s expand_aliases
+
+# This script serves to reflect in Atlas (gxa and scxa) private/public experiment status switch on the AE2 side.
+# private -> public or public -> private.
+# usage : public_private_ae2_to_atlas.sh <gxa or scxa>
+
 IFS="
 "
 
-if [ $# -ne 5 ]; then
-        echo "Usage: $0 ATLAS_URL AE2_URL ATLAS_ADMIN_UID ATLAS_ADMIN_PASS ERROR_NOTIFICATION_EMAILADDRESS" >&2
+if [ $# -ne 1 ]; then
+        echo "Usage: $0 GXA_OR_SCXA" >&2
         exit 1;
 fi
 
-ATLAS_URL=$1
-AE2_URL=$2
-ATLAS_ADMIN_UID=$3
-ATLAS_ADMIN_PASS=$4
-ERROR_NOTIFICATION_EMAILADDRESS=$5
+## gxa or scxa
+GXA_OR_SCXA=$1
+
+[ ! -z ${ATLAS_URL+x} ] || (echo "Env var ATLAS_URL not defined." && exit 1)
+[ ! -z ${AE2_URL+x} ] || (echo "Env var AE2_URL not defined." && exit 1)
+[ ! -z ${ATLAS_ADMIN_UID+x} ] || (echo "Env var ATLAS_ADMIN_UID not defined." && exit 1)
+[ ! -z ${ATLAS_ADMIN_PASS+x} ] || (echo "Env var ATLAS_ADMIN_PASS not defined." && exit 1)
+[ ! -z ${ERROR_NOTIFICATION_EMAILADDRESS+x} ] || (echo "Env var ERROR_NOTIFICATION_EMAILADDRESS not defined." && exit 1)
+
 
 SUCCESS_HTTP_RESPONSE=200
-process_file="$HOME/tmp/publicprivate_ae2_to_atlas."`eval date +%Y%m%d`
+process_file="$HOME/tmp/${GXA_OR_SCXA}_publicprivate_ae2_to_atlas."`eval date +%Y%m%d`
 rest_results_file=$process_file.rest_results
 all_atlas_experiments_file=$process_file.all_atlas_exps
 all_ae2_experiments_file=$process_file.all_ae2_exps
@@ -26,27 +35,47 @@ exps_not_in_ae2=$process_file.$$.exps_not_in_ae2
 exps_public_in_atlas=$process_file.$$.exps_public_in_atlas
 exps_private_in_atlas=$process_file.$$.exps_private_in_atlas
 
-expsDir=$ATLAS_EXPS
-if [ "$ATLAS_URL" == "ves-hx-77.ebi.ac.uk:8080/gxa" ]; then
-    expsDir=${expsDir}_test
-fi
-
 # Remove any previous $process_file
 rm -rf $process_file
 rm -rf $process_file.log
 touch $process_file.log
 
-# Fetch the list of experiment privacies in Atlas.
- # we will removing PanCancer experiments (E-MTAB-5200 and E-MTAB-5423) as they dont want to be checked, as we want to keep them public
- # in Atlas as they are officially private in ArrayExpress
-fetch_experiment_privacy_from_atlas.pl | grep -v "PROT\|ENAD" | grep -v "E-MTAB-5200\|E-MTAB-5423" > $all_atlas_experiments_file
-if [ $? -ne 0 ]; then
-    echo "Error getting privacy statuses from Atlas to sync with ArrayExpress." >> $process_file.log
-    mailx -s "[gxa/cron] Error getting privacy statuses from Atlas to sync with ArrayExpress." ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
-    exit 1
+
+if [ $GXA_OR_SCXA == 'gxa' ]; then
+  expsDir=$ATLAS_EXPS
+  if [ "$ATLAS_URL" == "ves-hx-77.ebi.ac.uk:8080/gxa" ]; then
+    expsDir=${expsDir}_test
+  fi
+
+  # Fetch the list of experiment privacies in Atlas.
+  # we will removing PanCancer experiments (E-MTAB-5200 and E-MTAB-5423) as they dont want to be checked, as we want to keep them public
+  # in Atlas as they are officially private in ArrayExpress
+  fetch_experiment_privacy_from_atlas.pl | grep -v "PROT\|ENAD" | grep -v "E-MTAB-5200\|E-MTAB-5423" > $all_atlas_experiments_file
+  if [ $? -ne 0 ]; then
+      echo "Error getting privacy statuses from Atlas to sync with ArrayExpress." >> $process_file.log
+      mailx -s "[${GXA_OR_SCXA}/cron] Error getting privacy statuses from Atlas to sync with ArrayExpress." ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+      exit 1
+  fi
+
 fi
 
-num_all_atlas_exps=`cat $all_atlas_experiments_file | wc -l`
+if [ $GXA_OR_SCXA == 'scxa' ]; then
+  expsDir=$ATLAS_SC_EXPERIMENTS
+  if [ "$ATLAS_URL" == "ves-hx-77.ebi.ac.uk:8080/gxa/sc" ]; then
+    expsDir=$ATLAS_SC_EXPERIMENTS
+  fi
+
+  ## Fetch the list of single cell studies accessions and associated privacy status from webAPI
+  curl -s -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} "${ATLAS_URL}/admin/experiments/all/list" | jq -r '.[].result | [.accession, .isPrivate] | @tsv' > $all_atlas_experiments_file
+  if [ $? -ne 0 ]; then
+      echo "Error getting privacy statuses from Single cell Atlas to sync with ArrayExpress." >> $process_file.log
+      mailx -s "[${GXA_OR_SCXA}/cron] Error getting privacy statuses from Single cell Atlas to sync with ArrayExpress." ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+      exit 1
+  fi
+
+fi 
+
+num_all_atlas_exps=$(cat $all_atlas_experiments_file | wc -l)
 echo "Found $num_all_atlas_exps experiments in $ATLAS_URL. Processing..."  >> $process_file.log
 
 # Retrieve all AE2 experiments into $all_ae2_experiments_file (ssv)
@@ -54,7 +83,7 @@ curl -X GET -s "http://${AE2_URL}/api/privacy.txt" > $all_ae2_experiments_file
 if [ ! -f $all_ae2_experiments_file ]; then
    err_msg="Updating private/public status of experiments on ${ATLAS_URL} was unsuccessful due failure to retrieve all AE2 experiments"
    echo $err_msg >> $process_file.log
-   mailx -s "[gxa/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+   mailx -s "[${GXA_OR_SCXA}/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
 fi
 
 for l in $(cat "$all_atlas_experiments_file"); do
@@ -71,36 +100,36 @@ for l in $(cat "$all_atlas_experiments_file"); do
                   if [ $atlas_private_flag == "true" ]; then
                         # Experiment public in AE2 and private in Atlas - make it public in Atlas
                         echo -e "\n$exp_accession - AE2: public; Atlas: private - status change in Atlas: private->public"  >> $process_file.log
-		                    curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public" >> $process_file.log
+                      curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public" >> $process_file.log
                         echo "$exp_accession" >> $exps_public_in_atlas
-		                    # At this point, the last line of $process_file.log should contain something like 'Experiment E-GEOD-10406 successfully updated.200'
-		                    # where 200 is the http response code - fail if the response code is not $SUCCESS_HTTP_RESPONSE
-		                    httpCode=`tail -1 $process_file.log | awk -F"]" '{print $NF}'`
-		                      if [ "$httpCode" -ne "$SUCCESS_HTTP_RESPONSE" ]; then
-			                         err_msg="http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public returned non-success http code: $httpCode. Failing..." >> $process_file.log
-			                         echo $err_msg >> $process_file.log
-			                         mailx -s "[gxa/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
-			                         exit 1
-		                      fi
+                      # At this point, the last line of $process_file.log should contain something like 'Experiment E-GEOD-10406 successfully updated.200'
+                      # where 200 is the http response code - fail if the response code is not $SUCCESS_HTTP_RESPONSE
+                      httpCode=`tail -1 $process_file.log | awk -F"]" '{print $NF}'`
+                        if [ "$httpCode" -ne "$SUCCESS_HTTP_RESPONSE" ]; then
+                            err_msg="http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_public returned non-success http code: $httpCode. Failing..." >> $process_file.log
+                            echo $err_msg >> $process_file.log
+                            mailx -s "[${GXA_OR_SCXA}/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+                            exit 1
+                        fi
                   fi
-		            # Make the experiments public ftp directory readable by public
-		              chmod 755 $expsDir/$exp_accession
+              # Make the experiments public ftp directory readable by public
+                chmod 755 $expsDir/$exp_accession
               elif [ ! -z $ae2_private_status ]; then
                    if [ $atlas_private_flag == "false" ]; then
                       # Experiment private in AE2 and public in Atlas - make it private in Atlas
                       echo -e "\n$exp_accession - AE2: private; Atlas: public - status change in Atlas: public->private" >> $process_file.log
-		                  curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private" >> $process_file.log
+                    curl -u ${ATLAS_ADMIN_UID}:${ATLAS_ADMIN_PASS} -X GET -s -w %{http_code} "http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private" >> $process_file.log
                       echo "$exp_accession" >> $exps_private_in_atlas
-		                  httpCode=`tail -1 $process_file.log | awk -F"]" '{print $NF}'`
-		                  if [ "$httpCode" -ne "$SUCCESS_HTTP_RESPONSE" ]; then
-		                        err_msg="http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private returned non-success http code: $httpCode. Failing..." >> $process_file.log
-		                        echo $err_msg >> $process_file.log
-		                        mailx -s "[gxa/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
-		                        exit 1
-                      fi	  
+                    httpCode=`tail -1 $process_file.log | awk -F"]" '{print $NF}'`
+                    if [ "$httpCode" -ne "$SUCCESS_HTTP_RESPONSE" ]; then
+                          err_msg="http://${ATLAS_URL}/admin/experiments/${exp_accession}/update_private returned non-success http code: $httpCode. Failing..." >> $process_file.log
+                          echo $err_msg >> $process_file.log
+                          mailx -s "[${GXA_OR_SCXA}/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+                          exit 1
+                      fi   
                    fi
-		            # Make the experiments public ftp directory unreadable by public
-		              chmod 750 $expsDir/$exp_accession	
+              # Make the experiments public ftp directory unreadable by public
+                chmod 750 $expsDir/$exp_accession 
                fi
           else
              err_msg="Updating private/public status of experiments on ${ATLAS_URL} unsuccessful: failed to find $exp_accession in AE2"
@@ -110,19 +139,19 @@ for l in $(cat "$all_atlas_experiments_file"); do
     else
           err_msg="Updating private/public status of experiments on ${ATLAS_URL} failed due to incorrect format of Atlas API call output"
           echo $err_msg >> $process_file.log
-          mailx -s "[gxa/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
+          mailx -s "[${GXA_OR_SCXA}/cron] $err_msg" ${ERROR_NOTIFICATION_EMAILADDRESS} < $process_file.log
           exit 1
     fi
 done
 
 # Notify of any experiments which gone public from private in Atlas.
 if [ -e $exps_public_in_atlas ]; then
-   mailx -s "[gxa/cron] Experiments status change in Atlas: private->public" ${ERROR_NOTIFICATION_EMAILADDRESS} < $exps_public_in_atlas
+   mailx -s "[${GXA_OR_SCXA}/cron] Experiments status change in Atlas: private->public" ${ERROR_NOTIFICATION_EMAILADDRESS} < $exps_public_in_atlas
 fi
 
 # Notify of any experiments which gone private from public in Atlas.
 if [ -e $exps_private_in_atlas ]; then
-   mailx -s "[gxa/cron] Experiments status change in Atlas: public->private" ${ERROR_NOTIFICATION_EMAILADDRESS} < $exps_private_in_atlas
+   mailx -s "[${GXA_OR_SCXA}/cron] Experiments status change in Atlas: public->private" ${ERROR_NOTIFICATION_EMAILADDRESS} < $exps_private_in_atlas
 fi
 
 echo -e "\nProcessed $num_all_atlas_exps experiments successfully" >> $process_file.log
@@ -134,3 +163,4 @@ rm -rf $exps_not_in_ae2
 rm -rf $rest_results_file
 rm -rf $exps_public_in_atlas
 rm -rf $exps_private_in_atlas
+


### PR DESCRIPTION
In this PR,
- Changes were reflected in to incorporate both GXA and SCXA private/public experiment status checks and switch based on the AE2 side.
- Experiment switch from `private -> public` or  `public -> private`.
- Improve CLI (env vars instead of positional arguments)
- Have a parameter that sets it to do GXA or SCXA
- Used webAPI to extract single-cell experiment and associated privacy status which avoids Perl dependency.

**Email notification**

![image](https://user-images.githubusercontent.com/20791369/86455449-88310480-bd18-11ea-8d76-f97ad2a4a7b8.png)
