### PR TITLE
Make cell id field less flexible to account for multiple occurence

### DIFF
--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -198,7 +198,7 @@ use_cell_types_In_condensed() {
       
       # Find the column in CT for the cell id and the metadata field
       col_num_ct=$( head -1 $CT | tr '\t' '\012' | nl | grep -iP "^\s+\d+\s+$field_to_extract$" | awk '{ print $1 }' )
-      col_num_cell_id=$( head -1 $CT | tr '\t' '\012' | nl | grep -i 'Cell ID' | awk '{ print $1 }' )
+      col_num_cell_id=$( head -1 $CT | tr '\t' '\012' | nl | grep -iP "^\s+\d+\s+Cell ID$" | awk '{ print $1 }' )
    
       if [ -n "$col_num_ct" ]; then 
         awk -v fieldName="$field_to_extract" -F'\t' 'BEGIN { OFS = "\t" } NR == FNR { cell[$1]; type[$1]=$2; next } $3 in cell { print $1, $2, $3, "factor", fieldName, type[$3] }' \


### PR DESCRIPTION
This just makes the regex that looks for the cell id field in .cells.txt less flexible. A curator REALLY wanted multiple fields with the 'cell id' substring, so we need to be stricter. 