### PR TITLE
Specify the cell type fields used by annotate_celltypes_condensed_sdrf.pl

### DIFF
--- a/annotate_celltypes_condensed_sdrf.pl
+++ b/annotate_celltypes_condensed_sdrf.pl
@@ -80,7 +80,7 @@ while(my $line = <COND_IN_2>) {
   chomp $line;
   my ($expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri) = split /\t/, $line;
   $uri = "" if( !$uri );
-  if($type eq $args->{"condensed_sdrf_path"}) {
+  if($type eq $args->{"cell_type_field"}) {
     my $organism = $cell2organism->{ $cell };
     my $annot_uri = $automaticMappings->{ $type }->{ $value }->{$organism};
     $uri = $annot_uri if( $annot_uri );

--- a/annotate_celltypes_condensed_sdrf.pl
+++ b/annotate_celltypes_condensed_sdrf.pl
@@ -55,7 +55,7 @@ while(my $line = <COND_IN>) {
   my ($expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri) = split /\t/, $line;
   $expAcc = $expAccAux;
   # we only care about cell types
-  $unique_properties->{ $type }->{ $value }->{ $cell } = 1 if $type =~ /.*cell type$/;
+  $unique_properties->{ $type }->{ $value }->{ $cell } = 1 if $type eq $args->{"cell_type_field"};
   # and run zooma needs the organism
   if ($type =~ /^organism$/ && !$cell2organism->{ $cell }) {
       my $org = lc $value;
@@ -80,7 +80,7 @@ while(my $line = <COND_IN_2>) {
   chomp $line;
   my ($expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri) = split /\t/, $line;
   $uri = "" if( !$uri );
-  if($type =~ /.*cell type$/) {
+  if($type eq $args->{"condensed_sdrf_path"}) {
     my $organism = $cell2organism->{ $cell };
     my $annot_uri = $automaticMappings->{ $type }->{ $value }->{$organism};
     $uri = $annot_uri if( $annot_uri );
@@ -90,7 +90,7 @@ while(my $line = <COND_IN_2>) {
 close(COND_IN_2);
 close($fh);
 
-$logger->info( "Successfully produced condensed SDRF with cell types annotated." );
+$logger->info( "Successfully produced condensed SDRF with cell types (by $args->{'cell_type_field'}) annotated." );
 
 
 
@@ -103,6 +103,7 @@ sub parse_args {
     GetOptions(
         "h|help"            => \$want_help,
         "c|condensed=s"    => \$args{ "condensed_sdrf_path" },
+        "e|cell_type_field=s"            => \$args{ "cell_type_field" },
         "x|exclusions_file=s"        => \$args{ "exclusions_file_path" },
         "o|out_condensed=s"        => \$args{ "output_sdrf_condensed" },
         "l|zoomifications_log=s"   => \$args{ "output_zoomifications" },
@@ -111,6 +112,14 @@ sub parse_args {
     unless( $args{ "condensed_sdrf_path" } ) {
         pod2usage(
             -message => "You must specify an input condensed_sdrf_path (-c).\n",
+            -exitval => 255,
+            -output => \*STDOUT,
+            -verbose => 1,
+        );
+    }
+    unless( $args{ "cell_type_field" } ) {
+        pod2usage(
+            -message => "You must specify an input cell type field (-e).\n",
             -exitval => 255,
             -output => \*STDOUT,
             -verbose => 1,

--- a/run_zooma_condensed.pl
+++ b/run_zooma_condensed.pl
@@ -55,7 +55,7 @@ while(my $line = <COND_IN>) {
   my ($expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri) = split /\t/, $line;
   $expAcc = $expAccAux;
   # we only care about cell types
-  $unique_properties->{ $type }->{ $value }->{ $cell } = 1 if $type eq $args->{"cell_type_field"};
+  $unique_properties->{ $type }->{ $value }->{ $cell } = 1;
   # and run zooma needs the organism
   if ($type =~ /^organism$/ && !$cell2organism->{ $cell }) {
       my $org = lc $value;
@@ -80,21 +80,15 @@ while(my $line = <COND_IN_2>) {
   chomp $line;
   my ($expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri) = split /\t/, $line;
   $uri = "" if( !$uri );
-  if($type eq $args->{"cell_type_field"}) {
-    my $organism = $cell2organism->{ $cell };
-    my $annot_uri = $automaticMappings->{ $type }->{ $value }->{$organism};
-    $uri = $annot_uri if( $annot_uri );
-  }
+  my $organism = $cell2organism->{ $cell };
+  my $annot_uri = $automaticMappings->{ $type }->{ $value }->{$organism};
+  $uri = $annot_uri if( $annot_uri );
   say $fh join("\t", $expAccAux, $arrayDesign, $cell, $attributeType, $type, $value, $uri);
 }
 close(COND_IN_2);
 close($fh);
 
-$logger->info( "Successfully produced condensed SDRF with cell types (by $args->{'cell_type_field'}) annotated." );
-
-
-
-
+$logger->info( "Successfully produced condensed SDRF with zooma terms annotated." );
 
 # Get commandline arguments.
 sub parse_args {
@@ -103,7 +97,6 @@ sub parse_args {
     GetOptions(
         "h|help"            => \$want_help,
         "c|condensed=s"    => \$args{ "condensed_sdrf_path" },
-        "e|cell_type_field=s"            => \$args{ "cell_type_field" },
         "x|exclusions_file=s"        => \$args{ "exclusions_file_path" },
         "o|out_condensed=s"        => \$args{ "output_sdrf_condensed" },
         "l|zoomifications_log=s"   => \$args{ "output_zoomifications" },
@@ -112,14 +105,6 @@ sub parse_args {
     unless( $args{ "condensed_sdrf_path" } ) {
         pod2usage(
             -message => "You must specify an input condensed_sdrf_path (-c).\n",
-            -exitval => 255,
-            -output => \*STDOUT,
-            -verbose => 1,
-        );
-    }
-    unless( $args{ "cell_type_field" } ) {
-        pod2usage(
-            -message => "You must specify an input cell type field (-e).\n",
             -exitval => 255,
             -output => \*STDOUT,
             -verbose => 1,

--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -220,7 +220,7 @@ use_cell_types_In_condensed() {
 }
 
 checkExecutableInPath condense_sdrf.pl
-checkExecutableInPath annotate_celltypes_condensed_sdrf.pl
+checkExecutableInPath run_zooma_condensed.pl
 
 # Figure out if the experiment has technical replicates
 hasTechnicalReplicates

--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -254,4 +254,6 @@ if [ -z "$skipZooma" ]; then
 
     annotateCommand="run_zooma_condensed.pl -c ${CONDENSED_SDRF_TSV} -o ${CONDENSED_SDRF_TSV}_zooma -l  $outputDir/$expId-zoomifications-log.tsv $exclusions"
     eval $annotateCommand
+
+    mv ${CONDENSED_SDRF_TSV}_zooma ${CONDENSED_SDRF_TSV} 
 fi

--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -203,20 +203,30 @@ use_cell_types_In_condensed() {
       if [ -n "$col_num_ct" ]; then 
         awk -v fieldName="$field_to_extract" -F'\t' 'BEGIN { OFS = "\t" } NR == FNR { cell[$1]; type[$1]=$2; next } $3 in cell { print $1, $2, $3, "factor", fieldName, type[$3] }' \
             <( awk -F'\t' -v cellCol=$col_num_cell_id -v ctCol=$col_num_ct 'BEGIN { OFS = "\t" } { print $cellCol, $ctCol }' $CT ) \
-            <( awk -F'\t' 'BEGIN { OFS = "\t" } {print $1, $2, $3}' $COND | sort | uniq) >> $COND\.with_ct
+            <( awk -F'\t' 'BEGIN { OFS = "\t" } {print $1, $2, $3}' $COND | sort | uniq) > $COND\.with_ct
+
+        actual_cell_type_field=$(head -1 $CT | awk -F"\t" -v col=$col_num_ct '{print $col}')
+        if [ -s $COND\.with_ct ]; then
+          echo "Found matches for $field_to_extract to add to the condensed..."
+          echo "Annotating $actual_cell_type_field cell types"          
+          annotateCommand="annotate_celltypes_condensed_sdrf.pl -c $CONDENSED_SDRF_TSV -o ${CONDENSED_SDRF_TSV}_celltypes -l ${CONDENSED_SDRF_TSV}_zoomalogs -e $actual_cell_type_field $exclusions"
+          eval $annotateCommand
+          
+          if [ "$?" = "0" ]; then # zooma mapping went fine
+            cat $CONDENSED_SDRF_TSV"_celltypes" >> $COND
+            # Append cell type zommification logs to main zoomification logs
+            tail -n+2 $CONDENSED_SDRF_TSV"_zoomalogs" >> $outputDir/$expId-zoomifications-log.tsv
+            rm $CONDENSED_SDRF_TSV"_zoomalogs"
+          fi
+  
+        else
+          echo "WARNING: No matches found between cell types file and the condensed SDRF for $actual_cell_type_field, please check"
+          echo $CT "and"
+          echo $COND
+        fi
+        rm -f $COND\.with_ct
       fi
   done
-  # if the file has content, merge it with the condensed.
-  # TODO in the future, we could have a Zooma call to get identifiers for each inferred cell type, before adding it to the condensed.
-  if [ -s $COND\.with_ct ]; then
-    echo "Found matches for $field_to_extract to add to the condensed..."
-    cat $COND\.with_ct >> $COND
-  else
-    echo "WARNING: No matches found between cell types file and the condensed SDRF, please check"
-    echo $CT "and"
-    echo $COND
-  fi
-  rm -f $COND\.with_ct
 }
 
 checkExecutableInPath condense_sdrf.pl
@@ -253,14 +263,4 @@ fi
 if [ -f "$cellTypesFile" ]; then
   echo "Found cell types file for $expId"
   use_cell_types_In_condensed
-  annotateCommand="annotate_celltypes_condensed_sdrf.pl -c $CONDENSED_SDRF_TSV -o ${CONDENSED_SDRF_TSV}_celltypes -l ${CONDENSED_SDRF_TSV}_zoomalogs $exclusions"
-  eval $annotateCommand
-
-  if [ "$?" = "0" ]; then # zooma mapping went fine
-    # replace condensed file with the new one that has cell type ontologies.
-    mv $CONDENSED_SDRF_TSV"_celltypes" $CONDENSED_SDRF_TSV
-    # Append cell type zommification logs to main zoomification logs
-    tail -n+2 $CONDENSED_SDRF_TSV"_zoomalogs" >> $outputDir/$expId-zoomifications-log.tsv
-    rm $CONDENSED_SDRF_TSV"_zoomalogs"
-  fi
 fi

--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -209,7 +209,7 @@ use_cell_types_In_condensed() {
         if [ -s $COND\.with_ct ]; then
           echo "Found matches for $field_to_extract to add to the condensed..."
           echo "Annotating $actual_cell_type_field cell types"          
-          annotateCommand="annotate_celltypes_condensed_sdrf.pl -c $CONDENSED_SDRF_TSV -o ${CONDENSED_SDRF_TSV}_celltypes -l ${CONDENSED_SDRF_TSV}_zoomalogs -e $actual_cell_type_field $exclusions"
+          annotateCommand="annotate_celltypes_condensed_sdrf.pl -c $COND\.with_ct -o ${CONDENSED_SDRF_TSV}_celltypes -l ${CONDENSED_SDRF_TSV}_zoomalogs -e $actual_cell_type_field $exclusions"
           eval $annotateCommand
           
           if [ "$?" = "0" ]; then # zooma mapping went fine


### PR DESCRIPTION
Currently can't test this properly due to multiple systems issues (hence the WIP). But basically I've relocated the cell type ontology expansion for droplet experiments to be within use_cell_types_In_condensed(), which has a concept of the specific cell type fields present and can pass those to the annotation script. This negates the need for a dodgy regex. 

Edit: the plan sort of evolved, to simplify logic and improve maintainability. The idea now is to deactivate Zooma running as part of the condense process, add in any additional condensed SDRF lines from .cells.txt files (where present), and then run Zooma on everything at the end. 