### PR TITLE
Add logic for setting a delimeter in field names of unmelted SDRF

### DIFF
--- a/unmelt_condensed.R
+++ b/unmelt_condensed.R
@@ -50,7 +50,7 @@ option_list = list(
     help = "Optional flag. Interpret 4th field as biorep identifier?"
   ),
   make_option(
-    c("-d", "--delimeter"),
+    c("-d", "--delimiter"),
     action = "store",
     default = NA,
     type = 'character',
@@ -179,8 +179,8 @@ if (opt[['has_ontology']]){
 }
 
 # Add field delimeter to prevent R from adding dots
-if(!is.na(opt$delimeter)){
-    colnames(wide) = gsub(" ", opt$delimeter, colnames(wide))
+if(!is.na(opt$delimiter)){
+    colnames(wide) = gsub(" ", opt$delimiter, colnames(wide))
 }
 # Write output
 

--- a/unmelt_condensed.R
+++ b/unmelt_condensed.R
@@ -50,6 +50,13 @@ option_list = list(
     help = "Optional flag. Interpret 4th field as biorep identifier?"
   ),
   make_option(
+    c("-d", "--delimeter"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = 'What delimeter should be added to field names instead of spaces? Default: none'
+  ),
+  make_option(
     c("-n", "--has-ontology"),
     action = "store_true",
     default = FALSE,
@@ -171,6 +178,10 @@ if (opt[['has_ontology']]){
   print("... done")
 }
 
+# Add field delimeter to prevent R from adding dots
+if(!is.na(opt$delimeter)){
+    colnames(wide) = gsub(" ", opt$delimeter, colnames(wide))
+}
 # Write output
 
 print("Writing reshaped output to file ...")


### PR DESCRIPTION
To avoid R's malicious actions when parsing text files, add an option for field names delimiters in unmelted SDRF files. 