### PR TITLE
Copy SDRF functionality to output dir

### DIFF
--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -12,6 +12,7 @@ setup() {
     implicit_pl_out_dir='implicit_pl'
     explicit_pl_out="${explicit_pl_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     implicit_pl_out="${implicit_pl_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
+    implicit_pl_output_sdrf="${implicit_pl_out_dir}/${test_exp_acc}.sdrf.txt"
     explicit_sc_sh_out_dir='explicit_sc_sh'
     implicit_sc_sh_out_dir='implicit_sc_sh'
     zooma_exclusions="test_data/zooma_exclusions.yml"
@@ -32,15 +33,16 @@ setup() {
     [ -f "$explicit_pl_out" ]
 }
 
-@test "Test single-cell condense perl script with implicit IDF" {
+@test "Test single-cell condense perl script with implicit IDF and SDRF copy" {
     if [ -f "$implicit_pl_out" ]; then
         skip "Output from implicit condense pl exists"
     fi
 
-    run mkdir -p $implicit_pl_out_dir && env ATLAS_PROD=$test_data_dir $condense_pl -sc -e $test_exp_acc -o $implicit_pl_out_dir
+    run mkdir -p $implicit_pl_out_dir && env ATLAS_PROD=$test_data_dir $condense_pl -sc -s -e $test_exp_acc -o $implicit_pl_out_dir
 
     [ "$status" -eq 0 ]
     [ -f "$implicit_pl_out" ]
+    [ -f "$implicit_pl_output_sdrf" ]
 }
 
 @test "Test single-cell condense wrapper with explicit IDF" {

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -335,6 +335,7 @@ sub copy_sdrf_to_output_dir {
         else {
             $logger->logdie( "Could not copy SDRF: $!" );
         }
+    }
 }
 
 sub create_all_atlas_assays {

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -45,6 +45,10 @@ Optional. Path to Factors XML config (e.g. E-MTAB-1829-factors.xml)
 
 Optional. Copy IDF file from ArrayExpress load directory to output directory.
 
+=item -s --copySDRF
+
+Optional. Copy SDRF file from the IDF determined location to the output directory.
+
 =item -o --outdir
 
 Optional. Destination directory for output file(s). Will use current working
@@ -164,8 +168,13 @@ my $reader = Bio::MAGETAB::Util::Reader->new( {
         ignore_datafiles    => 1
     });
 
-my $magetab = $reader->parse;
+my ($investigation, $magetab) = $reader->parse;
 $logger->info( "Successfully read MAGETAB." );
+
+if( $args->{ "copySDRF" } ) {
+    copy_sdrf_to_output_dir($investigation, $args{ "output_directory" })
+}
+
 $logger->info( "Merging technical replicates if available.") if( $args->{ "mergeTechReplicates" } );
 my $atlasAssays = create_all_atlas_assays( $magetab, $args->{ "mergeTechReplicates" } );
 $logger->debug( Dumper( $atlasAssays ) );
@@ -247,6 +256,7 @@ sub parse_args {
         "z|zooma"           => \$args{ "zooma" },
         "x|zoomaExclusions=s" => \$args{ "zooma_exclusions_path" },
         "i|idf"             => \$args{ "idf" },
+        "s|copySDRF"        => \$args{"copySDRF"},
         "f|factors=s"       => \$args{ "factors_file" },
         "b|bioreps"         => \$args{ "bioreps" },
         "d|debug"           => \$args{ "debug" },
@@ -306,6 +316,17 @@ sub copy_idf_from_ae {
     else {
         $logger->logdie( "Could not copy IDF: $!" );
     }
+}
+
+sub copy_sdrf_to_output_dir {
+    my ( $investigation, $output_dir, $idf_abs_path ) = @_;
+    foreach my $sdrf ( @{ $investigation->get_sdrfs() } ) {
+        $filename = $sdrf->get_uri()->file();
+        if( File::Spec->file_name_is_absolute( $filename ) ) {
+            # copy directly
+        } else {
+            # append IDF path
+        }
 }
 
 sub create_all_atlas_assays {

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -173,7 +173,7 @@ my ($investigation, $magetab) = $reader->parse;
 $logger->info( "Successfully read MAGETAB." );
 
 if( $args->{ "copySDRF" } ) {
-    copy_sdrf_to_output_dir($investigation, $args{ "output_directory" }, $idfFile);
+    copy_sdrf_to_output_dir($investigation, $args->{ "output_directory" }, $idfFile);
 }
 
 $logger->info( "Merging technical replicates if available.") if( $args->{ "mergeTechReplicates" } );
@@ -322,7 +322,7 @@ sub copy_idf_from_ae {
 sub copy_sdrf_to_output_dir {
     my ( $investigation, $output_dir, $idf_abs_path ) = @_;
     foreach my $sdrf ( @{ $investigation->get_sdrfs() } ) {
-        $filename = $sdrf->get_uri()->file();
+        my $filename = $sdrf->get_uri()->file();
         if( !File::Spec->file_name_is_absolute( $filename ) ) {
             # append IDF path
             my $dir = dirname($idf_abs_path);

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -173,7 +173,7 @@ my ($investigation, $magetab) = $reader->parse;
 $logger->info( "Successfully read MAGETAB." );
 
 if( $args->{ "copySDRF" } ) {
-    copy_sdrf_to_output_dir($investigation, $args{ "output_directory" });
+    copy_sdrf_to_output_dir($investigation, $args{ "output_directory" }, $idfFile);
 }
 
 $logger->info( "Merging technical replicates if available.") if( $args->{ "mergeTechReplicates" } );


### PR DESCRIPTION
Currently the condensed_sdrf script has a functionality to copy the IDF to the output directory, this gives the functionality to also copy the SDRF. This is needed to expose the SDRF files of baseline studies for meta-analysis.