### PR TITLE
Source default zooma exclusions file via env var, not assumed path

### DIFF
--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -15,7 +15,7 @@ setup() {
     implicit_pl_output_sdrf="${implicit_pl_out_dir}/${test_exp_acc}.sdrf.txt"
     explicit_sc_sh_out_dir='explicit_sc_sh'
     implicit_sc_sh_out_dir='implicit_sc_sh'
-    zooma_exclusions="test_data/zooma_exclusions.yml"
+    zooma_exclusions="$test_data_dir/zooma_exclusions.yml"
     explicit_sc_sh_out="${explicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     implicit_sc_sh_out="${implicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     celltype_fields="inferred cell type"
@@ -45,7 +45,7 @@ setup() {
     [ -f "$implicit_pl_output_sdrf" ]
 }
 
-@test "Test single-cell condense wrapper with explicit IDF" {
+@test "Test single-cell condense wrapper with explicit IDF and Zooma" {
     if [ -f "$explicit_sc_sh_out" ]; then
         skip "Output from SC sh condense wrapper exists"
     fi
@@ -56,12 +56,23 @@ setup() {
     [ -f "$explicit_sc_sh_out" ]
 }
 
-@test "Test single-cell condense wrapper with implicit IDF" {
+@test "Test single-cell condense wrapper with implicit IDF and Zooma" {
     if [ -f "$implicit_sc_sh_out" ]; then
         skip "Output from SC sh condense wrapper exists"
     fi
 
     run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dir -z $zooma_exclusions
+
+    [ "$status" -eq 0 ]
+    [ -f "$implicit_sc_sh_out" ]
+}
+
+@test "Test single-cell condense wrapper with implicit IDF and Zooma from env" {
+    if [ -f "$implicit_sc_sh_out" ]; then
+        skip "Output from SC sh condense wrapper exists"
+    fi
+
+    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dirs
 
     [ "$status" -eq 0 ]
     [ -f "$implicit_sc_sh_out" ]

--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -18,6 +18,7 @@ setup() {
     zooma_exclusions="$test_data_dir/zooma_exclusions.yml"
     explicit_sc_sh_out="${explicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     implicit_sc_sh_out="${implicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
+    implicit_sc_sh_out_env_exc="${implicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.env_exc.tsv"
     celltype_fields="inferred cell type"
 }
 
@@ -68,14 +69,14 @@ setup() {
 }
 
 @test "Test single-cell condense wrapper with implicit IDF and Zooma from env" {
-    if [ -f "$implicit_sc_sh_out" ]; then
+    if [ -f "$implicit_sc_sh_out_env_exc" ]; then
         skip "Output from SC sh condense wrapper exists"
     fi
 
     run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dirs
 
     [ "$status" -eq 0 ]
-    [ -f "$implicit_sc_sh_out" ]
+    [ -f "$implicit_sc_sh_out_env_exc" ]
 }
 
 @test "Test unmelt for condensed SDRFs" {

--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -73,7 +73,7 @@ setup() {
         skip "Output from SC sh condense wrapper exists"
     fi
 
-    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dirs
+    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dir
 
     [ "$status" -eq 0 ]
     [ -f "$implicit_sc_sh_out_env_exc" ]

--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -74,7 +74,7 @@ setup() {
         skip "Output from SC sh condense wrapper exists"
     fi
 
-    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_exc_out_dir
+    run mkdir -p $implicit_sc_sh_exc_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_exc_out_dir
 
     [ "$status" -eq 0 ]
     [ -f "$implicit_sc_sh_out_env_exc" ]

--- a/atlas-experiment-metadata-test.bats
+++ b/atlas-experiment-metadata-test.bats
@@ -15,10 +15,11 @@ setup() {
     implicit_pl_output_sdrf="${implicit_pl_out_dir}/${test_exp_acc}.sdrf.txt"
     explicit_sc_sh_out_dir='explicit_sc_sh'
     implicit_sc_sh_out_dir='implicit_sc_sh'
+    implicit_sc_sh_exc_out_dir='implicit_sc_sh_env_exc'
     zooma_exclusions="$test_data_dir/zooma_exclusions.yml"
     explicit_sc_sh_out="${explicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     implicit_sc_sh_out="${implicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
-    implicit_sc_sh_out_env_exc="${implicit_sc_sh_out_dir}/E-MTAB-6077.condensed-sdrf.env_exc.tsv"
+    implicit_sc_sh_out_env_exc="${implicit_sc_sh_exc_out_dir}/E-MTAB-6077.condensed-sdrf.tsv"
     celltype_fields="inferred cell type"
 }
 
@@ -73,7 +74,7 @@ setup() {
         skip "Output from SC sh condense wrapper exists"
     fi
 
-    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_out_dir
+    run mkdir -p $implicit_sc_sh_out_dir && env ATLAS_SC_EXPERIMENTS=$test_data_dir ATLAS_META_CONFIG=$test_data_dir bash single_cell_condensed_sdrf.sh -t "$celltype_fields" -e E-MTAB-6077 -o $implicit_sc_sh_exc_out_dir
 
     [ "$status" -eq 0 ]
     [ -f "$implicit_sc_sh_out_env_exc" ]

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -286,10 +286,12 @@ sub parse_args {
         print "WARN  - No output directory specified, will write output files in ", Cwd::cwd(), "\n";
         $args{ "output_directory" } = Cwd::cwd();
     }
-    unless($args{ "zooma_exclusions_path" }) {
-        my $defaultExclusionsFile=get_supporting_file('zooma_exclusions.yml');
-        print "Using default exclusions file path of $defaultExclusionsFile\n";
-        $args{ "zooma_exclusions_path" } = $defaultExclusionsFile ;
+    if($args{ "zooma" } ){
+        unless($args{ "zooma_exclusions_path" }) {
+            my $defaultExclusionsFile=get_supporting_file('zooma_exclusions.yml');
+            print "Using default exclusions file path of $defaultExclusionsFile\n";
+            $args{ "zooma_exclusions_path" } = $defaultExclusionsFile ;
+        }
     }
 
     # If one was specified, check that it's writable and die if not.

--- a/condense_sdrf.pl
+++ b/condense_sdrf.pl
@@ -105,6 +105,7 @@ use Atlas::Common qw(
     get_idfFile_path
     get_singlecell_idfFile_path
 );
+use Atlas::Util qw( get_supporting_file);
 use Atlas::ZoomaClient;
 use Atlas::ZoomaClient::MappingResult;
 use Atlas::AtlasConfig::Reader qw( parseAtlasFactors );
@@ -286,7 +287,7 @@ sub parse_args {
         $args{ "output_directory" } = Cwd::cwd();
     }
     unless($args{ "zooma_exclusions_path" }) {
-        my $defaultExclusionsFile="$abs_path/../supporting_files/zooma_exclusions.yml";
+        my $defaultExclusionsFile=get_supporting_file('zooma_exclusions.yml');
         print "Using default exclusions file path of $defaultExclusionsFile\n";
         $args{ "zooma_exclusions_path" } = $defaultExclusionsFile ;
     }

--- a/run_zooma_condensed.pl
+++ b/run_zooma_condensed.pl
@@ -131,7 +131,6 @@ sub parse_args {
 
 sub run_zooma_mapping {
     my ( $allPropertiesAssays, $cell2organism, $zoomaExclusionsFilename, $zoomificationsFilename, $expAcc ) = @_;
-    #my $zoomaExclusionsFile = "$abs_path/../supporting_files/zooma_exclusions.yml";
     my $zoomaExclusions = Config::YAML->new(
         config => $zoomaExclusionsFilename
     ) if $zoomaExclusionsFilename;

--- a/single_cell_condensed_sdrf.sh
+++ b/single_cell_condensed_sdrf.sh
@@ -18,7 +18,7 @@ expId="$EXP_ID"
 idfFile=
 experimentDir="$ATLAS_SC_EXPERIMENTS"
 skipZooma="$SKIP_ZOOMA"
-zoomaExclusions="$scriptDir/../supporting_files/zooma_exclusions.yml"
+zoomaExclusions="$ATLAS_META_CONFIG/zooma_exclusions.yml"
 outputDir=
 
 while getopts ":e:f:s:o:z:t:" o; do

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -3,7 +3,7 @@ dependencies:
   - bats
   - coreutils
   - perl
-  - perl-atlas-modules
+  - perl-atlas-modules>=0.3.1
   - libgfortran
   - r-optparse=1.6.0
   - r-reshape2


### PR DESCRIPTION
Change default path for the zooma exclusions file to come via ATLAS_META_CONFIG (using mechanism created in https://github.com/ebi-gene-expression-group/perl-atlas-modules/pull/17) rather than a risky path assumption.

So the exclusions file can now be supplied in two ways:

 - Provide file explicitly via command line args.
 - Place file under a directory in ATLAS_META_CONFIG 