### PR TITLE
Add memory handling to zooma mapping workflow

### DIFF
--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -98,6 +98,7 @@ rule run_condense_sdrf:
         expand("{logspath}/{{accession}}/{{accession}}-run_condense_sdrf.log",logspath=logs_path)
     resources:
         load=config['load_zooma_jobs'],
+        mem_mb=get_mem_mb,
         attempt_number = lambda wildcards, attempt: attempt
     input:
         config_xml=lambda wildcards: f"{working_dir}/{wildcards.accession}/{wildcards.accession}-configuration.xml" if 'bulk' in config['mode'] else f"{logs_path}/{wildcards.accession}/check_zooma.done" ,

--- a/zooma-mappings-wf/rules/common.smk
+++ b/zooma-mappings-wf/rules/common.smk
@@ -95,3 +95,4 @@ def get_mem_mb(wildcards, attempt):
     """
     mem_avail = [ 4, 8, 16, 32 ]  
     return mem_avail[attempt-1] * 1000
+

--- a/zooma-mappings-wf/rules/common.smk
+++ b/zooma-mappings-wf/rules/common.smk
@@ -86,3 +86,12 @@ def get_split_zooma_mapping_report_inputs(accessions, lp):
     for acc in accessions:
         inputs.append(f"{lp}/{acc}/{acc}-apply_fixes_zooma_mappings.done")
     return inputs
+
+def get_mem_mb(wildcards, attempt):
+    """
+    To adjust resources in the rules 
+    attemps = reiterations + 1
+    Max number attemps = 4
+    """
+    mem_avail = [ 4, 8, 16, 32 ]  
+    return mem_avail[attempt-1] * 1000


### PR DESCRIPTION
We have noticed that rule condense_sdrf require more than default memory for some single cell experiments.

The retrial mechanism in Snakemake will now assign higher memory in subsequent run attempts.