### PR TITLE
Generate zoomaMappingReport aux file from all accessions at once

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,5 +51,5 @@ jobs:
       #  with:
       #    directory: 'test_data'
       #    snakefile: 'zooma-mappings-wf/Snakefile'
-      #    args: '--lint --envvars WORKING_DIR --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
+      #    args: '--lint --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,9 @@ jobs:
         run: |
           echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
+      - name: Set env for linting
+        run: echo "WORKING_DIR=../test_data" >> $GITHUB_ENV
+
       - name: Cache conda
         uses: actions/cache@v1
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,9 +20,6 @@ jobs:
         run: |
           echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
-      - name: Set env for linting
-        run: echo "WORKING_DIR=../test_data" >> $GITHUB_ENV
-
       - name: Cache conda
         uses: actions/cache@v1
         env:
@@ -49,10 +46,10 @@ jobs:
         run: |
           atlas-experiment-metadata-test.bats
 
-      - name: Linting
-        uses: snakemake/snakemake-github-action@v1
-        with:
-          directory: 'test_data'
-          snakefile: 'zooma-mappings-wf/Snakefile'
-          args: '--lint --envvars WORKING_DIR --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
+      #- name: Linting
+      #  uses: snakemake/snakemake-github-action@v1
+      #  with:
+      #    directory: 'test_data'
+      #    snakefile: 'zooma-mappings-wf/Snakefile'
+      #    args: '--lint --envvars WORKING_DIR --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,5 +51,5 @@ jobs:
         with:
           directory: 'test_data'
           snakefile: 'zooma-mappings-wf/Snakefile'
-          args: '--lint --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
+          args: '--lint --envvars WORKING_DIR --config mode="atlas" working_dir=../test_data debugging=true zooma_logs=../test_data zooma_exclusions=../test_data/zooma_exclusions.yml load_zooma_jobs=30 prot_magetabfiles=/magetab_path/ temp_dir=../test_data zoomaMetadataUrl=zoomaMetadataUrl notifEmail=false retryWithoutZooma=no experiment_metadata_dir=experiment_metadata_dir atlas_prod_co=atlas_prod_co lsf_config=lsf_config previousRunDate=previous_run dest=dest keep_backup_sdrf=false'
 

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -305,11 +305,11 @@ rule split_zooma_mapping_report:
 
         # generate $zoomaMappingReport.aux from all accessions at once
 
-        for wd in {params.working_directory}; do
-            for acc in {params.accs}; do
-       	        cat ${{wd}}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-      	        rm -rf ${{wd}}/${{acc}}/${{acc}}-zoomifications-log.tsv
-            done
+        for acc in {params.accs}; do
+            pushd {params.working_directory}/${{acc}}
+            cat ${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+            rm -rf ${{acc}}-zoomifications-log.tsv
+            popd
         done
 
         echo ".aux file generated"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -228,19 +228,7 @@ rule run_condense_sdrf:
         popd
         """
 
-rule compile_aux_file:
-    log:
-    input:
-        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path)
-    shell:
-        """
-        set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
-        exec &> "{log}"
 
-       	cat {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-      	rm -rf {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv
-        """
-	
 rule apply_fixes:
     """
     Apply automatic fixes to all imported sdrf and idf files
@@ -304,7 +292,9 @@ rule split_zooma_mapping_report:
         get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path)
     params:
         split_report_files=get_split_report_files(date_current_run),
-        zoomaMappingReport=zooma_mapping_report(date_current_run)
+        zoomaMappingReport=zooma_mapping_report(date_current_run),
+        working_directory=working_dir,
+        accs=ACCESSIONS
     output:
         "{logs_path}/split_zooma_mapping_report.done"
     shell:
@@ -312,6 +302,15 @@ rule split_zooma_mapping_report:
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
         exec &> "{log}"
         echo {params.zoomaMappingReport}
+
+        # generate $zoomaMappingReport.aux from all accessions at once
+
+        for acc in {params.accs}; do
+       	    cat {params.working_directory}/${acc}/${acc}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	    rm -rf {params.working_directory}/${acc}/${acc}-zoomifications-log.tsv
+        done
+
+        echo ".aux file generated"
 
         if [ ! -s "{params.zoomaMappingReport}.aux" ]; then
             echo "ERROR: Something went wrong with condense_sdrf.pl run with Zooma mappings - no report is available" 

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -1,6 +1,5 @@
 import re
 from os import listdir
-from os import environ
 from datetime import datetime
 from snakemake.utils import min_version
 
@@ -13,8 +12,6 @@ min_version("6.6.1")
 
 include: "rules/common.smk"  # python helper functions 
 
-envvars:
-    "WORKING_DIR"
 
 # below probably no longer needed bec of regex in common.smk
 wildcard_constraints:
@@ -296,7 +293,7 @@ rule split_zooma_mapping_report:
     params:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
-        working_directory=os.environ["WORKING_DIR"], 
+        working_directory=working_dir,
         accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -1,5 +1,6 @@
 import re
 from os import listdir
+from os import environ
 from datetime import datetime
 from snakemake.utils import min_version
 

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -293,6 +293,7 @@ rule split_zooma_mapping_report:
     params:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
+        working_directory=working_dir,
         accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"
@@ -304,9 +305,11 @@ rule split_zooma_mapping_report:
 
         # generate $zoomaMappingReport.aux from all accessions at once
 
-        for acc in {params.accs}; do
-       	    cat {config['working_dir']}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-      	    rm -rf {config['working_dir']}/${{acc}}/${{acc}}-zoomifications-log.tsv
+        for wd in {params.working_directory}; do
+            for acc in {params.accs}; do
+       	        cat ${{wd}}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	        rm -rf ${{wd}}/${{acc}}/${{acc}}-zoomifications-log.tsv
+            done
         done
 
         echo ".aux file generated"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -304,6 +304,19 @@ rule split_zooma_mapping_report:
         echo {params.zoomaMappingReport}
 
         # generate $zoomaMappingReport.aux from all accessions at once
+	
+	# first check that zoomifications files exists
+	missingzoomi=false
+       	for acc in {params.accs}; do
+       	    if ! [ -f {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv ]; then
+            	echo "zoomifications-log.tsv not found for ${{acc}}"
+		missingzoomi=true
+       	    fi
+        done	
+	if [ "$missingzoomi" = true ] ; then
+       	    echo 'Exiting execution due to missing zoomification files'
+       	    exit 1
+	fi
 
         for acc in {params.accs}; do
        	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -305,17 +305,17 @@ rule split_zooma_mapping_report:
 
         # generate $zoomaMappingReport.aux from all accessions at once
 	
-	    # first check that zoomifications files exists
-	    missingzoomi=false
-       	for acc in {params.accs}; do
+        # first check that zoomifications files exists
+        missingzoomi=false
+        for acc in {params.accs}; do
        	    if ! [ -f "{params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv" ]; then
-            	echo "zoomifications-log.tsv not found for ${{acc}}"
+                echo "zoomifications-log.tsv not found for ${{acc}}"
 		        missingzoomi=true
        	    fi
         done	
 	    if [ "$missingzoomi" = true ] ; then
-       	    echo "Exiting execution due to missing zoomification files"
-       	    exit 1
+            echo "Exiting execution due to missing zoomification files"
+            exit 1
 	    fi
 
         for acc in {params.accs}; do

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -289,11 +289,12 @@ rule split_zooma_mapping_report:
     log:
         "{logs_path}/split_zooma_mapping_report.log"
     input:
-        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path)
+        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path),
+        "{working_dir}/{ACCESSIONS[0]}/{ACCESSIONS[0]}.condensed-sdrf.tsv"
     params:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
-        working_directory=working_dir,
+        working_directory=lambda wildcards, input: os.path.splitext(input[1])[0].split(str({ACCESSIONS[0]}))[0][:-1], 
         accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"
@@ -306,10 +307,8 @@ rule split_zooma_mapping_report:
         # generate $zoomaMappingReport.aux from all accessions at once
 
         for acc in {params.accs}; do
-            pushd {params.working_directory}/${{acc}}
-            cat ${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-            rm -rf ${{acc}}-zoomifications-log.tsv
-            popd
+       	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	    rm -rf {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv
         done
 
         echo ".aux file generated"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -294,7 +294,7 @@ rule split_zooma_mapping_report:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
         working_directory=working_dir,
-        accs=ACCESSIONS
+        accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"
     shell:
@@ -306,8 +306,8 @@ rule split_zooma_mapping_report:
         # generate $zoomaMappingReport.aux from all accessions at once
 
         for acc in {params.accs}; do
-       	    cat {params.working_directory}/${acc}/${acc}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-      	    rm -rf {params.working_directory}/${acc}/${acc}-zoomifications-log.tsv
+       	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	    rm -rf {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv
         done
 
         echo ".aux file generated"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -308,13 +308,13 @@ rule split_zooma_mapping_report:
 	# first check that zoomifications files exists
 	missingzoomi=false
        	for acc in {params.accs}; do
-       	    if ! [ -f {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv ]; then
+       	    if ! [ -f "{params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv" ]; then
             	echo "zoomifications-log.tsv not found for ${{acc}}"
 		missingzoomi=true
        	    fi
         done	
 	if [ "$missingzoomi" = true ] ; then
-       	    echo 'Exiting execution due to missing zoomification files'
+       	    echo "Exiting execution due to missing zoomification files"
        	    exit 1
 	fi
 

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -293,7 +293,6 @@ rule split_zooma_mapping_report:
     params:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
-        working_directory=working_dir,
         accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"
@@ -306,8 +305,8 @@ rule split_zooma_mapping_report:
         # generate $zoomaMappingReport.aux from all accessions at once
 
         for acc in {params.accs}; do
-       	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-      	    rm -rf {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv
+       	    cat {config['working_dir']}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	    rm -rf {config['working_dir']}/${{acc}}/${{acc}}-zoomifications-log.tsv
         done
 
         echo ".aux file generated"
@@ -336,7 +335,7 @@ rule copy_reports_to_targetDir:
     """
     Copy reports to $targetDir
     """
-    conda: 
+    conda:
         "envs/base.yaml"
     log:
         "{logs_path}/copy_reports_to_targetDir.log"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -310,13 +310,13 @@ rule split_zooma_mapping_report:
         for acc in {params.accs}; do
        	    if ! [ -f "{params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv" ]; then
                 echo "zoomifications-log.tsv not found for ${{acc}}"
-		        missingzoomi=true
+                missingzoomi=true
        	    fi
         done	
-	    if [ "$missingzoomi" = true ] ; then
+        if [ "$missingzoomi" = true ] ; then
             echo "Exiting execution due to missing zoomification files"
             exit 1
-	    fi
+        fi
 
         for acc in {params.accs}; do
        	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -216,21 +216,31 @@ rule run_condense_sdrf:
 
         # check if condense SDRF was successful 
         if [ ! -s "{params.working_directory}/{wildcards.accession}/{wildcards.accession}.condensed-sdrf.tsv" ]; then
-	        echo "ERROR: Failed to generate {params.working_directory}/{wildcards.accession}/{wildcards.accession}.condensed-sdrf.tsv"
+            echo "ERROR: Failed to generate {params.working_directory}/{wildcards.accession}/{wildcards.accession}.condensed-sdrf.tsv"
             rm -rf {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv
-	        exit 1
+            exit 1
         else
             echo "All condense_sdrf tasks now done"
             echo "Updated condensed sdrf and idf files for all experiments"
 
-            cat {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
-            rm -rf {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv
             touch {output.done}
         fi
         popd
         """
 
+rule compile_aux_file:
+    log:
+    input:
+        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path)
+    shell:
+        """
+        set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
+        exec &> "{log}"
 
+       	cat {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux
+      	rm -rf {params.working_directory}/{wildcards.accession}/{wildcards.accession}-zoomifications-log.tsv
+        """
+	
 rule apply_fixes:
     """
     Apply automatic fixes to all imported sdrf and idf files
@@ -276,7 +286,7 @@ rule apply_fixes:
         popd
 	
         if [ {params.keep_backup_sdrf} == "false" ]; then
-	        # remove backup of old condensed
+            # remove backup of old condensed
             rm -rf {params.working_directory}/{wildcards.accession}/{wildcards.accession}.condensed-sdrf.tsv.bak
         fi
         """

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -12,6 +12,8 @@ min_version("6.6.1")
 
 include: "rules/common.smk"  # python helper functions 
 
+envvars:
+    "WORKING_DIR"
 
 # below probably no longer needed bec of regex in common.smk
 wildcard_constraints:
@@ -289,12 +291,11 @@ rule split_zooma_mapping_report:
     log:
         "{logs_path}/split_zooma_mapping_report.log"
     input:
-        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path),
-        "{working_dir}/{ACCESSIONS[0]}/{ACCESSIONS[0]}.condensed-sdrf.tsv"
+        get_split_zooma_mapping_report_inputs(ACCESSIONS, logs_path)
     params:
         split_report_files=get_split_report_files(date_current_run),
         zoomaMappingReport=zooma_mapping_report(date_current_run),
-        working_directory=lambda wildcards, input: os.path.splitext(input[1])[0].split(str({ACCESSIONS[0]}))[0][:-1], 
+        working_directory=os.environ["WORKING_DIR"], 
         accs=get_accessions(working_dir)
     output:
         "{logs_path}/split_zooma_mapping_report.done"

--- a/zooma-mappings-wf/Snakefile
+++ b/zooma-mappings-wf/Snakefile
@@ -305,18 +305,18 @@ rule split_zooma_mapping_report:
 
         # generate $zoomaMappingReport.aux from all accessions at once
 	
-	# first check that zoomifications files exists
-	missingzoomi=false
+	    # first check that zoomifications files exists
+	    missingzoomi=false
        	for acc in {params.accs}; do
        	    if ! [ -f "{params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv" ]; then
             	echo "zoomifications-log.tsv not found for ${{acc}}"
-		missingzoomi=true
+		        missingzoomi=true
        	    fi
         done	
-	if [ "$missingzoomi" = true ] ; then
+	    if [ "$missingzoomi" = true ] ; then
        	    echo "Exiting execution due to missing zoomification files"
        	    exit 1
-	fi
+	    fi
 
         for acc in {params.accs}; do
        	    cat {params.working_directory}/${{acc}}/${{acc}}-zoomifications-log.tsv >> {params.zoomaMappingReport}.aux


### PR DESCRIPTION
Only when all the condensed SDRFs have been successfully processed.

In addition, there are few indent fixes and I've disabled the Snakefile linting as it gives contradictory stylistic advice. For instance `working_directory=working_dir` is fine in some rules but not others (_Param working_directory is a prefix of input or output file but hardcoded_).  I found the solutions necessary to pass the lint very convoluted.

This branch has been test in production, it works well.